### PR TITLE
chore(deps): update golan from 1.26.1 to 1.26.2

### DIFF
--- a/.github/workflows/relativity-ci.yml
+++ b/.github/workflows/relativity-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Azure Login
         uses: Azure/login@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
       # On tag, get tag version without v (e.g. v1.0.0 -> 1.0.0, v1.1.1-beta -> 1.1.1-beta)
       - name: Get tag version
         id: get_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-bookworm AS dev
+FROM golang:1.26.2-bookworm AS dev
 
 FROM dev AS build
 ARG VERSION="local"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redboxllc/scuttle
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/cenk/backoff v2.1.1+incompatible


### PR DESCRIPTION
Resolves vulnerability **CVE-2026-32280**

This pull request updates the project to use Go version 1.26.2 across all relevant configuration files and workflows. This ensures consistency in the development environment and CI/CD pipelines.

Go version upgrade:

* Updated the Go version from 1.26.1 to 1.26.2 in the `Dockerfile`, ensuring the development image uses the latest version.
* Updated the Go version in the `go.mod` file to 1.26.2 to reflect the project's required Go version.

CI/CD workflow updates:

* Updated the Go version to 1.26.2 in the `relativity-ci.yml` GitHub Actions workflow.
* Updated the Go version to 1.26.2 in the `release.yaml` GitHub Actions workflow.