### PR TITLE
chore(deps): update golang from 1.26.2 to 1.26.3

### DIFF
--- a/.github/workflows/relativity-ci.yml
+++ b/.github/workflows/relativity-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
 
       - name: Azure Login
         uses: Azure/login@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
       # On tag, get tag version without v (e.g. v1.0.0 -> 1.0.0, v1.1.1-beta -> 1.1.1-beta)
       - name: Get tag version
         id: get_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-bookworm AS dev
+FROM golang:1.26.3-bookworm AS dev
 
 FROM dev AS build
 ARG VERSION="local"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redboxllc/scuttle
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/cenk/backoff v2.1.1+incompatible


### PR DESCRIPTION
Resolving the following stdlib vulnerabilities (all published 2026-05-07, present in Go stdlib `1.26.2`, fix versions `1.26.3` / `1.25.10`):

```
name           severity publish_date resource version fix_version
----           -------- ------------ -------- ------- -----------
CVE-2026-33811 -        2026-05-07   stdlib   1.26.2  1.26.3, 1.25.10
CVE-2026-33814 -        2026-05-07   stdlib   1.26.2  1.26.3, 1.25.10
CVE-2026-39820 -        2026-05-07   stdlib   1.26.2  1.26.3, 1.25.10
CVE-2026-39836 -        2026-05-07   stdlib   1.26.2  1.26.3, 1.25.10
CVE-2026-42499 -        2026-05-07   stdlib   1.26.2  1.26.3, 1.25.10
```

The currently published image (`r1k8sacrdev.azurecr.io/r1/analytics/scuttle:v1.3.31-rel`, built from tag `v1.3.31-rel`) embeds `go1.26.2` in its BuildInfo, which is what Aqua/Trivy flags in downstream consumers (notably `relativityone/reporting-data-flows`). This is a pure Go-toolchain bump — the transitive Go-module deps (`x/net v0.42.0`, `x/text v0.27.0`, `protobuf v1.36.6`) are already on patched versions, so no `go.sum` changes are needed.

This pull request updates the project to use Go version 1.26.3 across all relevant configuration files and workflows. This ensures consistency in the development environment and CI/CD pipelines.

Go version upgrade:

* Updated the Go version from 1.26.2 to 1.26.3 in the `Dockerfile`, ensuring the development image uses the latest version.
* Updated the Go version in the `go.mod` file to 1.26.3 to reflect the project's required Go version.

CI/CD workflow updates:

* Updated the Go version to 1.26.3 in the `relativity-ci.yml` GitHub Actions workflow.
* Updated the Go version to 1.26.3 in the `release.yaml` GitHub Actions workflow.

Verified locally with `go mod tidy` and `go build ./...` inside `golang:1.26.3-bookworm`; no `go.sum` changes were required.

Made with [Cursor](https://cursor.com)