### PR TITLE
fix: bump Go to 1.26.4 to patch CVE-2026-42504

### DIFF
--- a/.github/workflows/relativity-ci.yml
+++ b/.github/workflows/relativity-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Azure Login
         uses: Azure/login@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
       # On tag, get tag version without v (e.g. v1.0.0 -> 1.0.0, v1.1.1-beta -> 1.1.1-beta)
       - name: Get tag version
         id: get_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-bookworm AS dev
+FROM golang:1.26.4-bookworm AS dev
 
 FROM dev AS build
 ARG VERSION="local"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redboxllc/scuttle
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cenk/backoff v2.1.1+incompatible


### PR DESCRIPTION
## Summary

CVE-2026-42504 (high, published 2026-06-02) affects Go stdlib v1.26.3. Fix versions: Go 1.25.11 or 1.26.4.

This is blocking the Aqua scan in gpt-candidate-experiments (and prefect-infra), which COPY the scuttle binary from the ACR image.

**Changes:**
- `go.mod`: `go 1.26.3` → `go 1.26.4`
- `Dockerfile`: `golang:1.26.3-bookworm` → `golang:1.26.4-bookworm`
- `.github/workflows/release.yaml`: `go-version: 1.26.3` → `1.26.4`
- `.github/workflows/relativity-ci.yml`: `go-version: 1.26.3` → `1.26.4`

## After merge

Tag `v1.3.33-rel` on main to trigger `relativity-ci.yml`, which builds and pushes the new image to ACR. Then bump consumers:
- `relativityone/gpt-candidate-experiments` Dockerfile line 54
- `relativityone/prefect-infra` Dockerfile line 48

Fixes: REL-1312617, REL-1312618, REL-1312619