### PR TITLE
Bump golang to 1.26.5

### DIFF
--- a/.github/workflows/relativity-ci.yml
+++ b/.github/workflows/relativity-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Azure Login
         uses: Azure/login@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
       # On tag, get tag version without v (e.g. v1.0.0 -> 1.0.0, v1.1.1-beta -> 1.1.1-beta)
       - name: Get tag version
         id: get_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm AS dev
+FROM golang:1.26.5-bookworm AS dev
 
 FROM dev AS build
 ARG VERSION="local"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redboxllc/scuttle
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cenk/backoff v2.1.1+incompatible


### PR DESCRIPTION
In order to fix scuttle vulns we bumped go version to 1.26.5